### PR TITLE
Patching error in bidirectional relationship maintenance.

### DIFF
--- a/Instrument/src/model/Orchestra.java
+++ b/Instrument/src/model/Orchestra.java
@@ -7,8 +7,8 @@ import java.util.ArrayList;
 
 public class Orchestra {
 
-    private ArrayList<BrassInstrument> brassInstruments = new ArrayList<>();
-    private ArrayList<StringInstrument> stringInstruments = new ArrayList<>();
+    private final ArrayList<BrassInstrument> brassInstruments;
+    private final ArrayList<StringInstrument> stringInstruments;
 
     public Orchestra(ArrayList<BrassInstrument> brassInstruments, ArrayList<StringInstrument> stringInstruments) {
         this.brassInstruments = brassInstruments;
@@ -22,10 +22,24 @@ public class Orchestra {
         }
     }
 
+    public void removeBrassInstrument(BrassInstrument b) {
+        if(brassInstruments.contains(b)) {
+            brassInstruments.remove(b);
+            b.removeOrchestra();
+        }
+    }
+
     public void addStringInstrument(StringInstrument s) {
         if(!stringInstruments.contains(s)) {
             stringInstruments.add(s);
             s.setOrchestra(this);
+        }
+    }
+
+    public void removeStringInstrument(StringInstrument s) {
+        if(stringInstruments.contains(s)) {
+            stringInstruments.remove(s);
+            s.removeOrchestra();
         }
     }
 

--- a/Instrument/src/model/instrument/BrassInstrument.java
+++ b/Instrument/src/model/instrument/BrassInstrument.java
@@ -11,9 +11,21 @@ public abstract class BrassInstrument implements Instrument {
     }
 
     public void setOrchestra(Orchestra orchestra) {
-        if (!this.orchestra.equals(orchestra)) {
+        if (!orchestra.equals(this.orchestra)) {
+            Orchestra oldOrchestra = this.orchestra;
             this.orchestra = orchestra;
+            if (oldOrchestra != null) {
+                oldOrchestra.removeBrassInstrument(this);
+            }
             orchestra.addBrassInstrument(this);
+        }
+    }
+
+    public void removeOrchestra() {
+        if (orchestra != null) {
+            Orchestra oldOrchestra = orchestra;
+            orchestra = null;
+            oldOrchestra.removeBrassInstrument(this);
         }
     }
 

--- a/Instrument/src/model/instrument/StringInstrument.java
+++ b/Instrument/src/model/instrument/StringInstrument.java
@@ -11,9 +11,21 @@ public abstract class StringInstrument implements Instrument {
     }
 
     public void setOrchestra(Orchestra orchestra) {
-        if (!this.orchestra.equals(orchestra)) {
+        if (!orchestra.equals(this.orchestra)) {
+            Orchestra oldOrchestra = this.orchestra;
             this.orchestra = orchestra;
+            if (oldOrchestra != null) {
+                oldOrchestra.removeStringInstrument(this);
+            }
             orchestra.addStringInstrument(this);
+        }
+    }
+
+    public void removeOrchestra() {
+        if (orchestra != null) {
+            Orchestra oldOrchestra = orchestra;
+            orchestra = null;
+            oldOrchestra.removeStringInstrument(this);
         }
     }
 


### PR DESCRIPTION
CPSC student Erica Buchanan pointed out the following scenario: We create two empty orchestras o1 and o2 and an instrument (say a Trumpet) i. Now, o1.addBrassInstrument(i) and o1 has i while i has o1. Now, o2.addBrassInstrument(i), ond o2 has i while i has o2 AND o1 still has i.

To correct this, we have two options. (1) We need to disallow adding an instrument to an orchestra if it already has an orchestra. We could do this in a REQUIRES (and perhaps throw on IllegalArgumentException). I chose not to. (2) We need to be able to REMOVE an instrument from an orchestra. If we can remove instruments from orchestras as a public method, we must also be able to remove orchestras from instruments.

(Also patched for the two quite accurate warnings about redundant initializers in Orchestra given by IntelliJ.)